### PR TITLE
Document CI fix for Metrics workflow crash

### DIFF
--- a/CI_FIX.md
+++ b/CI_FIX.md
@@ -1,0 +1,33 @@
+# CI Fix Required
+
+## Problem
+
+The `Metrics` workflow (`.github/workflows/stats.yaml`) crashes with:
+
+```
+TypeError: Cannot destructure property 'committer' of 'undefined' as it is undefined.
+    at RecentAnalyzer.patches (plugins/languages/analyzer/recent.mjs:70:12)
+Error: Process completed with exit code 1.
+```
+
+The `lowlighter/metrics@latest` action crashes in `RecentAnalyzer` when some commits
+in the repository have a `null` committer field. This is triggered by the
+`recently-used` section of `plugin_languages_sections`.
+
+## Fix
+
+In `.github/workflows/stats.yaml`, change line 39:
+
+```diff
+-          plugin_languages_sections: most-used, recently-used
++          plugin_languages_sections: most-used
+```
+
+This removes the `recently-used` section which uses the crashing `RecentAnalyzer`.
+The `most-used` section is unaffected and will continue to work normally.
+
+## Why this wasn't applied automatically
+
+The Claude Code OAuth token does not have the `workflow` scope required to push
+changes to `.github/workflows/` files. Apply the one-line change above manually
+and push.


### PR DESCRIPTION
## Summary
Added documentation describing a required fix for the failing Metrics workflow that crashes due to null committer fields in the repository history.

## Changes
- Added `CI_FIX.md` documenting the `TypeError` in the `lowlighter/metrics@latest` action's `RecentAnalyzer`
- Provided the specific one-line fix needed in `.github/workflows/stats.yaml` (removing `recently-used` from `plugin_languages_sections`)
- Explained why the fix wasn't applied automatically (missing `workflow` scope in OAuth token)

## Details
The Metrics workflow crashes when processing commits with null committer fields. The fix removes the `recently-used` section from the language plugin configuration, which triggers the crashing analyzer. The `most-used` section remains unaffected and continues to function normally.

This is a documentation-only change; the actual workflow file modification must be applied manually.

https://claude.ai/code/session_01SC9NkiN9WgL5meKtSxBD4t